### PR TITLE
feat: add showcase reminder message after page generation

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -34,6 +34,7 @@ const CONSTANTS = {
         CONFIG_CREATED: 'Sample config.json created successfully!',
         CONFIG_EDIT_INSTRUCTIONS: 'Edit config.json with your information and run "npx opentwig" to generate your page.',
         PAGE_GENERATED: '🎉 Page generated successfully!',
+        SHOWCASE_REMINDER: '🌟 Don\'t forget to add your site in showcase: https://github.com/tufantunc/opentwig',
         UNKNOWN_OPTION: 'Unknown option:',
         USE_HELP: 'Use --help for usage information.',
         ERROR_PREFIX: '❌ Error:',

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ const main = async () => {
         
         // Success message
         console.log(CONSTANTS.MESSAGES.PAGE_GENERATED);
+        console.log(CONSTANTS.MESSAGES.SHOWCASE_REMINDER);
         
     } catch (error) {
         console.error(`${CONSTANTS.MESSAGES.ERROR_PREFIX} ${error.message}`);


### PR DESCRIPTION
## What does this PR do?
Adds a friendly reminder message after successful page generation encouraging users to share their site in the project showcase.

## What changed?
- Added `SHOWCASE_REMINDER` constant in `src/constants.js` with message and GitHub repo link
- Updated `src/index.js` to display the showcase reminder after the success message
- Message displays: "🌟 Don't forget to add your site in showcase: https://github.com/tufantunc/opentwig"

## Related issues
Closes #5 

## Testing
- [x] Tested locally
- [x] Works with different themes (if applicable)

**Testing Steps:**
1. Ran `node src/index.js --init` to create config
2. Ran `node src/index.js` to generate page
3. Verified both success message and showcase reminder are displayed:
   - ✅ `🎉 Page generated successfully!`
   - ✅ `🌟 Don't forget to add your site in showcase: https://github.com/tufantunc/opentwig`

## Screenshots
Terminal output after running the command:

<img width="818" height="78" alt="image" src="https://github.com/user-attachments/assets/09bfa7d2-8d0a-4383-ad03-4d075192f23b" />

## Type of change
- [ ] Bug fix
- [x] New feature  
- [ ] Documentation
- [ ] Style/theme
- [ ] Showcase submission

## Showcase Submission (if applicable)
N/A