### PR TITLE
fix(theme): use dynamic OG meta tags and escape HTML content

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "opentwig": "./src/index.js"
   },
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test-og": "node test-og.js"
   },
   "repository": {
     "type": "git",

--- a/src/utils/escapeHTML.js
+++ b/src/utils/escapeHTML.js
@@ -1,0 +1,10 @@
+// Escapes HTML special characters to prevent injection/malformed HTML
+module.exports = function escapeHTML(str = '') {
+  return String(str).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  }[c]));
+};

--- a/test-og.js
+++ b/test-og.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const renderTemplate = require('./theme/default/index');
+
+const html = renderTemplate({
+  title: 'Tom & Jerry <Best Show>',
+  content: `O'Reilly's "Guide" & More`,
+  url: 'https://example.com',
+  name: 'Test User',
+  avatar: '',
+  links: [],
+  footerLinks: [],
+  share: {}
+});
+
+const outPath = path.resolve(__dirname, 'test-output.html');
+fs.writeFileSync(outPath, html, 'utf8');
+console.log('HTML written to', outPath);
+
+// Basic checks
+function assert(condition, msg) {
+  if (!condition) {
+    console.error('Assertion failed:', msg);
+    process.exitCode = 1;
+    throw new Error(msg);
+  }
+}
+
+assert(html.includes('<title>Tom &amp; Jerry &lt;Best Show&gt;</title>'), 'title not escaped as expected');
+assert(html.includes('<meta name="description" content="O&#39;Reilly&#39;s &quot;Guide&quot; &amp; More">'), 'description not escaped as expected');
+assert(html.includes('<meta property="og:title" content="Tom &amp; Jerry &lt;Best Show&gt;"'), 'og:title not escaped as expected');
+assert(html.includes('<meta property="og:description" content="O&#39;Reilly&#39;s &quot;Guide&quot; &amp; More"'), 'og:description not escaped as expected');
+assert(html.includes('<div class="tagline">O&#39;Reilly&#39;s &quot;Guide&quot; &amp; More</div>'), 'tagline not escaped as expected');
+
+console.log('All checks passed.');

--- a/theme/default/index.js
+++ b/theme/default/index.js
@@ -6,16 +6,24 @@ const qrComponent = require('./components/qr');
 const dialogComponent = require('./components/dialog');
 
 module.exports = function({title, url, name, content, avatar, links, footerLinks, share}) {
+  const escapeHTML = (str = '') => String(str).replace(/[&<>"']/g, c => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  }[c]));
+
   return `<!DOCTYPE html>
   <html lang="en">
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>${title}</title>
-      <meta name="description" content="${content}">
+      <title>${escapeHTML(title)}</title>
+      <meta name="description" content="${escapeHTML(content)}">
       <link rel="stylesheet" href="./style.css">
-      <meta property="og:title" content="tufantunc | Twitter | Linktree"/>
-      <meta property="og:description" content="Merhaba."/>
+      <meta property="og:title" content="${escapeHTML(title)}"/>
+      <meta property="og:description" content="${escapeHTML(content)}"/>
       <meta property="og:url" content="${url}"/>
       <meta property="og:image" content="${url}/og-image.jpg"/>
     </head>
@@ -28,8 +36,8 @@ module.exports = function({title, url, name, content, avatar, links, footerLinks
 
           <div class="profile">
             ${avatarComponent({avatar})}
-            <div class="name">${name}</div>
-            <div class="tagline">${content}</div>
+            <div class="name">${escapeHTML(name)}</div>
+            <div class="tagline">${escapeHTML(content)}</div>
           </div>
 
           <div class="links">

--- a/theme/default/index.js
+++ b/theme/default/index.js
@@ -4,15 +4,9 @@ const footerLinkComponent = require('./components/footer-link');
 const shareButtonComponent = require('./components/share-button');
 const qrComponent = require('./components/qr');
 const dialogComponent = require('./components/dialog');
+const escapeHTML = require('../../src/utils/escapeHTML');
 
 module.exports = function({title, url, name, content, avatar, links, footerLinks, share}) {
-  const escapeHTML = (str = '') => String(str).replace(/[&<>"']/g, c => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;'
-  }[c]));
 
   return `<!DOCTYPE html>
   <html lang="en">
@@ -22,10 +16,10 @@ module.exports = function({title, url, name, content, avatar, links, footerLinks
       <title>${escapeHTML(title)}</title>
       <meta name="description" content="${escapeHTML(content)}">
       <link rel="stylesheet" href="./style.css">
-      <meta property="og:title" content="${escapeHTML(title)}"/>
-      <meta property="og:description" content="${escapeHTML(content)}"/>
-      <meta property="og:url" content="${url}"/>
-      <meta property="og:image" content="${url}/og-image.jpg"/>
+  <meta property="og:title" content="${escapeHTML(title)}"/>
+  <meta property="og:description" content="${escapeHTML(content)}"/>
+  <meta property="og:url" content="${escapeHTML(url)}"/>
+  <meta property="og:image" content="${escapeHTML(url)}/og-image.jpg"/>
     </head>
     <body>
       <div class="app-bg">


### PR DESCRIPTION
### Summary

This PR addresses and resolves issue #8 by replacing hardcoded Open Graph (OG) meta tags in the default theme with dynamic values (`title`, `content`, and `url`). Additionally, it introduces proper HTML escaping to prevent malformed HTML when user-provided content contains special characters like `<`, `>`, `&`, `"`, or `'`.

### Key Changes

- Replaced hardcoded OG meta tags with dynamic template values:
  - `<meta property="og:title">`
  - `<meta property="og:description">`
  - `<meta property="og:url">`
  - `<meta property="og:image">`
- Escaped user-provided values in both `<head>` and `<body>` sections:
  - `<title>`, `<meta name="description">`
  - `<meta property="og:title">`, `<meta property="og:description">`
  - `.name` and `.tagline` in the body
- Added a helper function `escapeHTML()` to safely encode special characters
- Created a test script `test-og.js` to render a sample page and assert that meta tags and body content are properly escaped
- Added a test command in `package.json` for convenience: `npm run test-og`

### Testing

- Run `npm run test-og` to generate a sample HTML file (`test-output.html`)
- The script asserts that all dynamic values are correctly escaped in the HTML output
- Manual inspection of the generated file confirms the fix works as expected

### Fixes

Fixes: #8
