### PR TITLE
Feature/svg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The avatar feature is completely optional. If you don't include the `avatar` obj
 - PNG
 - JPG/JPEG  
 - WebP
+- SVG
 
 **Avatar processing:**
 - Images are automatically optimized and resized

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentwig",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentwig",
-      "version": "1.0.3",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.21",

--- a/src/utils/generateOGImage.js
+++ b/src/utils/generateOGImage.js
@@ -2,8 +2,37 @@ const sharp = require('sharp');
 const readImageAsBase64 = require('./readImageAsBase64');
 
 module.exports = async function({name, content, avatar}) {
-    const avatarBase64 = avatar && avatar.path ? readImageAsBase64(avatar.path) : null;
-    // Create SVG with the same dimensions and styling as the original HTML
+    const avatarInfo = avatar && avatar.path ? readImageAsBase64(avatar.path) : { isSvg: false, content: '' };
+
+    // If avatar is SVG, we'll inline the markup and use a clipPath to make it circular.
+    // For raster images, keep using a data URI in an <image> element.
+    let avatarElement = '';
+    let avatarDefs = '';
+
+    if (avatarInfo && avatarInfo.isSvg && avatarInfo.content) {
+        // Ensure the inlined SVG has a root <svg> — if not, wrap it.
+        let inlined = avatarInfo.content.trim();
+        if (!/^<svg[\s>]/i.test(inlined)) {
+            inlined = `<svg xmlns=\"http://www.w3.org/2000/svg\">${inlined}</svg>`;
+        }
+
+        // Give the inlined SVG an id so we can reference it with <use>
+        // Remove any existing id attributes to avoid collisions
+        inlined = inlined.replace(/\s(id=\"[^\"]*\")/ig, '');
+        const symbolId = 'avatar-svg';
+
+        // Put the avatar SVG inside a <g> with an id inside <defs>
+        avatarDefs = `<defs><clipPath id="avatar-clip"><circle cx="48" cy="48" r="48"/></clipPath><g id="${symbolId}">${inlined}</g></defs>`;
+
+        // Use a foreignObject to render the SVG content into a 96x96 box and clip it
+        // Some renderers don't allow referencing inline <svg> via <use> with complex markup, so use <g> directly
+        avatarElement = `<g transform="translate(504,267)"><svg x="0" y="0" width="96" height="96" viewBox="0 0 96 96" preserveAspectRatio="xMidYMid slice" clip-path="url(#avatar-clip)">${inlined}</svg></g>`;
+
+    } else if (avatarInfo && avatarInfo.content) {
+        // Raster image data URI
+        avatarElement = `<image href="${avatarInfo.content}" x="504" y="267" width="96" height="96" clip-path="circle(48px at 48px 48px)"/>`;
+    }
+
     const svg = `
         <svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
             <defs>
@@ -21,25 +50,37 @@ module.exports = async function({name, content, avatar}) {
                     }
                 </style>
             </defs>
-            
+            ${avatarDefs}
+
             <!-- Background -->
             <rect width="1200" height="630" fill="#2d2d2d"/>
-            
+
             <!-- Avatar circle background -->
             <circle cx="552" cy="315" r="48" fill="#dedede"/>
-            
+
             <!-- Avatar image (if provided) -->
-            ${avatarBase64 ? `<image href="${avatarBase64}" x="504" y="267" width="96" height="96" clip-path="circle(48px at 48px 48px)"/>` : ''}
-            
+            ${avatarElement}
+
             <!-- Text content -->
-            <text x="660" y="300" class="name-text">${name}</text>
-            <text x="660" y="325" class="content-text">${content}</text>
+            <text x="660" y="300" class="name-text">${escapeXml(name)}</text>
+            <text x="660" y="325" class="content-text">${escapeXml(content)}</text>
         </svg>
     `;
-    
+
     // Convert SVG to JPG
     const jpgBuffer = await sharp(Buffer.from(svg))
         .jpeg({ quality: 90 })
         .toBuffer();
     return jpgBuffer;
+}
+
+// Minimal XML escaping for text nodes
+function escapeXml(unsafe) {
+    if (!unsafe) return '';
+    return String(unsafe)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
 }


### PR DESCRIPTION
## What does this PR do?
Creates inline SVG avatars when generating the Open Graph image so SVG avatars render correctly when rasterized to JPG.

## What changed?

- _readImageAsBase64.js_ now returns `{ isSvg: boolean, content: string }`. SVG files return raw SVG markup (XML, prolog stripped) rasrer images now return a date URI in **content**

- _generateOGImage.js_ inlines the SVG markup and clips to the circle for SVG avatars. Raster images still uses a data URI `<images>` element. Added basic XML escaping for the text.

## Related issues
<!-- Closes #123 -->

## Testing
- `npm install`
- `npm start` --> confirmed `index.html`, `dist/og-image.jpg`, `dist/qr.svg` and `dist/avatar.svg` are generated avatar renders.

## Type of change
- [ ] Bug fix
- [X] New feature  
- [ ] Documentation
- [ ] Style/theme
- [ ] Showcase submission

**Theme Used:** 
Default theme used