### PR TITLE
feat: resize avatar images to 96x96px PNG during build

### DIFF
--- a/src/utils/buildPage.js
+++ b/src/utils/buildPage.js
@@ -8,6 +8,9 @@ const generateHTML = require('./generateHTML');
 const processCSS = require('./processCSS');
 const generateOGImage = require('./generateOGImage');
 const generateQR = require('./generateQR');
+const sharp = require('sharp');
+const path = require('path');
+const fs = require('fs');
 
 /**
  * Build all page components from configuration
@@ -31,6 +34,11 @@ const buildPage = async (config) => {
         // Generate QR Code (async)
         const qrImage = await generateQR(config.url);
         
+        // Process avatar
+        if (config.avatar && config.avatar.path) {
+            await processAvatar(config.avatar.path, config.outputDir);
+        }
+
         return {
             html,
             css,
@@ -42,5 +50,21 @@ const buildPage = async (config) => {
         throw new Error(`Failed to build page: ${error.message}`);
     }
 };
+
+async function processAvatar(avatarPath, outputDir) {
+  const ext = path.extname(avatarPath).toLowerCase();
+  const allowed = ['.png', '.jpg', '.jpeg', '.webp'];
+  const skipResize = ['.svg', '.gif'];
+  const outputAvatar = path.join(outputDir, 'avatar.png');
+
+  if (allowed.includes(ext)) {
+    await sharp(avatarPath)
+      .resize(96, 96, { fit: 'cover' })
+      .png()
+      .toFile(outputAvatar);
+  } else if (skipResize.includes(ext)) {
+    fs.copyFileSync(avatarPath, path.join(outputDir, path.basename(avatarPath)));
+  }
+}
 
 module.exports = buildPage;


### PR DESCRIPTION
## What does this PR do?
Resizes avatar images to a square 96x96px PNG during the build process for performance and consistency. Skips resizing for SVG and GIF files.

## What changed?
Added [processAvatar](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function to resize/crop PNG, JPG, JPEG, and WebP avatars to 96x96px PNG.
SVG and GIF avatars are copied as-is.
Integrated avatar processing into the build process in [buildPage.js](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

## Related issues
 Closes #9 

## Testing
- [x] Tested locally
- [x] Works with different themes (if applicable)

## Screenshots
<img width="652" height="856" alt="image" src="https://github.com/user-attachments/assets/7c526f77-f4b0-4af3-8303-e146e9ec4509" />

## Type of change
- [ ] Bug fix
- [x] New feature  
- [ ] Documentation
- [ ] Style/theme
- [ ] Showcase submission

## Showcase Submission (if applicable)
**Website URL:** 
<!-- If this is a showcase submission, provide the URL -->

**Theme Used:** 
<!-- Which theme was used? -->

**Brief Description:** 
<!-- 1-2 sentence description of the site -->